### PR TITLE
Fix instructions pointing to non-existant notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Jupyter is an ipython notebook where you can run blocks of code and see results 
 
 `> jupyter notebook`
 
-A browser window will appear showing the contents of the current directory.  Navigate to the P0\_prototype directory, and click on the file called "P0\_prototype.ipynb".  Another browser window will appear displaying the notebook.  Follow the instructions in the notebook to complete the project.  
+A browser window will appear showing the contents of the current directory.  Click on the file called "P1.ipynb".  Another browser window will appear displaying the notebook.  Follow the instructions in the notebook to complete the project.  


### PR DESCRIPTION
Noticed this wasn't correct, hopefully this helps. Should it be P1 though? In the classroom it seems to be called P0