### PR TITLE
Lambda to gamma

### DIFF
--- a/P1.ipynb
+++ b/P1.ipynb
@@ -226,7 +226,7 @@
     "\n",
     "# Python 3 has support for cool math symbols.\n",
     "\n",
-    "def weighted_img(img, initial_img, α=0.8, β=1., λ=0.):\n",
+    "def weighted_img(img, initial_img, α=0.8, β=1., γ=0.):\n",
     "    \"\"\"\n",
     "    `img` is the output of the hough_lines(), An image with lines drawn on it.\n",
     "    Should be a blank image (all black) with lines drawn on it.\n",
@@ -235,10 +235,10 @@
     "    \n",
     "    The result image is computed as follows:\n",
     "    \n",
-    "    initial_img * α + img * β + λ\n",
+    "    initial_img * α + img * β + γ\n",
     "    NOTE: initial_img and img must be the same shape!\n",
     "    \"\"\"\n",
-    "    return cv2.addWeighted(initial_img, α, img, β, λ)"
+    "    return cv2.addWeighted(initial_img, α, img, β, γ)"
    ]
   },
   {


### PR DESCRIPTION
Happened to notice:
![image](https://user-images.githubusercontent.com/214396/34660035-088fbd9c-f3f4-11e7-8492-69e051af86e2.png)

And the corresponding OpenCV func ([which references gamma, not lambda](https://docs.opencv.org/2.4/modules/core/doc/operations_on_arrays.html#addweighted)):
![image](https://user-images.githubusercontent.com/214396/34660061-2239c1c0-f3f4-11e7-9790-98e20ca46b67.png)

The proposed version now looks like:
![image](https://user-images.githubusercontent.com/214396/34660077-5b70bf98-f3f4-11e7-8635-8a442f06926a.png)


:)